### PR TITLE
Update tfdata.shuffle buffer_size

### DIFF
--- a/tf2.5/scripts/train_model.py
+++ b/tf2.5/scripts/train_model.py
@@ -175,7 +175,7 @@ for f in args.FOLDS:
                                                                           output_shapes = EXPECTED_IO_SHAPE)       # Initialize TensorFlow Dataset
     if str(args.CACHE_TDS_PATH)!='None': 
         train_gen = train_gen.cache(filename=(None if str(args.CACHE_TDS_PATH)=='None' else args.CACHE_TDS_PATH))  # Cache Dataset on Remote Server
-    train_gen     = train_gen.shuffle(int(TRAIN_DATA_SAMPLES*0.50))                                                # Shuffle Samples
+    train_gen     = train_gen.shuffle(int(TRAIN_DATA_SAMPLES))                                                     # Shuffle Samples
     train_gen     = train_gen.map(lambda x,y: augment_tensors(x,y,args.AUGM_PARAMS,args.TRAIN_OBJ), 
                                                               num_parallel_calls=multiprocessing.cpu_count())
     train_gen     = train_gen.batch(args.BATCH_SIZE)                                                               # Load Data in Batches


### PR DESCRIPTION
From the TF documentation: "For perfect shuffling, a buffer size greater than or equal to the full size of the dataset is required."
https://github.com/tensorflow/tensorflow/blob/3aa40c3ce9d16eae296f086bc4ac4d62deb2affc/tensorflow/python/data/ops/dataset_ops.py#L1300